### PR TITLE
Document the SHORTENER_GENERATOR_PRESERVE_NAME config option

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -19,8 +19,9 @@ Installing Thumbor Community Shortener
 
 7. Configure the extension within the same file:
 ::
-    SHORTENER_STORAGE   = 'tc_shortener.storages.redis_storage'         # Shortener storage class name
-    SHORTENER_GENERATOR = 'tc_shortener.generators.sha256_generator'    # Shortener generator class name
+    SHORTENER_STORAGE                 = 'tc_shortener.storages.redis_storage'         # Shortener storage class name
+    SHORTENER_GENERATOR               = 'tc_shortener.generators.sha256_generator'    # Shortener generator class name
+    SHORTENER_GENERATOR_PRESERVE_NAME = False                                         # Shortener generator option to use the original filename as part of the short url key
 
 8. Launch thumbor with the Thumbor Community custom application:
 ::


### PR DESCRIPTION
By default the shortener will include the original filename,
resulting in confusing and long keys. For first time users,
as I was, it appears that the shortener is not working correctly
when a key preserves the filename.

I expected keys like:

`e529d3807fdb0b84a92a6e4fa0c7a707e7a77f1d98443ad07b0bdc0cfca621fb`

But instead got

`e529d3807fdb0b84a92a6e4fa0c7a707e7a77f1d98443ad07b0bdc0cfca621fb/http://www.waterfalls.hamilton.ca/images/Waterfall_Collage_home_sm1.jpg`
